### PR TITLE
update zfetch

### DIFF
--- a/gyro.zzz
+++ b/gyro.zzz
@@ -13,5 +13,5 @@ pkgs:
 
 deps:
   mattnite/tar: ^0.0.1
-  truemedian/zfetch: ^0.0.1
+  truemedian/zfetch: ^0.1.1
   mattnite/uri: ^0.0.0


### PR DESCRIPTION
The current zfetch version depends on hzzp 0.0.3 which is broken with the latest zig master:
```
./.gyro/hzzp-truemedian-0.0.3-8baaab77884a746b7a2638681cc66144/pkg/src/base/client.zig:155:64: error: expected type 'std.fmt.Case', found 'bool'
                        try std.fmt.formatInt(payload.len, 16, false, .{}, self.writer);
                                                               ^
/home/vincent/dev/devtools/zig/lib/std/fmt.zig:732:18: note: std.fmt.Case declared here
pub const Case = enum { lower, upper };
                 ^
./.gyro/hzzp-truemedian-0.0.3-8baaab77884a746b7a2638681cc66144/pkg/src/base/client.zig:155:46: note: referenced here
                        try std.fmt.formatInt(payload.len, 16, false, .{}, self.writer);
                                             ^
build...The following command exited with error code 1:
```

The latest zfetch fixes this.